### PR TITLE
Reworked plugin API, added argument parsing, first pass at storage API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .env
 tsconfig.tsbuildinfo
+storage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/TEMPLATE.env
+++ b/TEMPLATE.env
@@ -11,3 +11,7 @@ PREFIX="."
 # Should a command running successfully block another command with the same name from running?
 # Default: true
 COMMAND_SHADOWING=true
+
+# Where to store storage files
+# Default: "./storage/"
+STORAGE_PATH="./storage/"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { Client, Intents } from "discord.js";
+import { StorageManager } from "./storage";
 
 const allIntents = new Intents(Object.values(Intents.FLAGS));
 
@@ -8,12 +9,16 @@ const nonPrivilegedIntents = allIntents.remove([
 ]);
 
 // As far as plugin code is concerned the client should always be ready.
-export type GompeiClient = Client<true>;
+export interface GompeiClient extends Client<true> {
+    storage: StorageManager;
+}
 
 let client: GompeiClient;
 
 export function getClient() {
-    return (client ??= new Client({
+    return (client ??= Object.assign(new Client<true>({
         intents: allIntents
+    }), {
+        storage: new StorageManager()
     }));
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,5 +3,6 @@ declare module NodeJS {
         BOT_TOKEN?: string;
         PREFIX?: string;
         COMMAND_SHADOWING?: boolean;
+        STORAGE_PATH?: string;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,9 @@ client.on('ready', async () => {
                 for (const command of textCommandsLookup[commandName]) {
                     // Run the commands until we get the first blocking (i.e. successful) one.
                     if (await command(Object.assign(msg, {
-                        parseArguments: parseArgumentsFactory(restOfContent)
-                    } as Omit<TextCommandContext, keyof Message>))) {
+                        parseArguments: parseArgumentsFactory(restOfContent),
+                        async parseArgumentsAsync(...args) { return Promise.all(parseArgumentsFactory(restOfContent).apply(this, args)); }
+                    } as TextCommandContext))) {
                         if (process.env.COMMAND_SHADOWING !== false) {
                             break;
                         }

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,9 +1,10 @@
 import { Awaited, ClientEvents, Message } from "discord.js";
 import { GompeiClient } from "../client";
-import parseArgumentsFactory from "../util/parseCommandArguments";
+import { ArgumentList, ParseArgumentsReturnType } from "../util/parseCommandArguments";
 
 export interface TextCommandContext extends Message {
-    parseArguments: ReturnType<typeof parseArgumentsFactory>;
+    parseArguments<T extends ArgumentList>(this: TextCommandContext, ...types: T): ParseArgumentsReturnType<T>;
+    parseArgumentsAsync<T extends ArgumentList>(this: TextCommandContext, ...types: T): Promise<ClearPromises<ParseArgumentsReturnType<T>>>;
 }
 
 interface TextCommandInfo {

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,6 +1,7 @@
 import { Awaited, ClientEvents, Message } from "discord.js";
 import { GompeiClient } from "../client";
 import { ArgumentList, ParseArgumentsReturnType } from "../util/parseCommandArguments";
+import { ClearPromises } from "../util/types";
 
 export interface TextCommandContext extends Message {
     parseArguments<T extends ArgumentList>(this: TextCommandContext, ...types: T): ParseArgumentsReturnType<T>;

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,26 +1,26 @@
 import { Awaited, ClientEvents, Message } from "discord.js";
 import { GompeiClient } from "../client";
+import parseArgumentsFactory from "../util/parseCommandArguments";
 
 export interface TextCommandContext extends Message {
-    argumentContent: string;
+    parseArguments: ReturnType<typeof parseArgumentsFactory>;
 }
 
 interface TextCommandInfo {
     commandName: string;
     aliases?: string[];
     description?: string;
-    // Need to do this wonky thing with type parameters so that
-    // typescript doesn't try to use the parameter for type inference
-    /** Return false if command fails and has no side effects */
-    callback: (ctx: TextCommandContext) => Awaited<boolean | void>;
+    check?: (ctx: TextCommandContext) => Awaited<boolean>;
+    callback(ctx: TextCommandContext): Awaited<void>;
 }
 
 export interface PluginInfo {
     name: string;
+    latch?: Promise<void>;
     description?: string;
     textCommands?: TextCommandInfo[];
     slashCommands?: never; // not yet implemented
-    eventListeners?: { [EventName in keyof ClientEvents]: (...args: ClientEvents[EventName]) => Awaited<void> };
+    eventListeners?: { [EventName in keyof ClientEvents]?: (...args: ClientEvents[EventName]) => Awaited<void> };
 }
 
 export type Plugin = (client: GompeiClient) => PluginInfo;

--- a/src/plugins/Plugin.ts
+++ b/src/plugins/Plugin.ts
@@ -1,29 +1,30 @@
 import { Awaited, ClientEvents, Message } from "discord.js";
 import { GompeiClient } from "../client";
-import { Thisify } from "../util/types";
 
-export type TextCommandContext = Message;
+export interface TextCommandContext extends Message {
+    argumentContent: string;
+}
 
-interface TextCommandInfo<TState, UseThis extends boolean> {
+interface TextCommandInfo {
     commandName: string;
     aliases?: string[];
     description?: string;
     // Need to do this wonky thing with type parameters so that
     // typescript doesn't try to use the parameter for type inference
-    permissions?: Thisify<UseThis, <T extends TState>(state: T, ctx: TextCommandContext) => Awaited<boolean>>;
-    callback: Thisify<UseThis, <T extends TState>(state: T, ctx: TextCommandContext) => Awaited<void>>;
+    /** Return false if command fails and has no side effects */
+    callback: (ctx: TextCommandContext) => Awaited<boolean | void>;
 }
 
-export interface Plugin<TState, UseThis extends boolean = boolean> {
+export interface PluginInfo {
     name: string;
     description?: string;
-    useThis?: UseThis;
-    init?: (client: GompeiClient) => Awaited<TState>;
-    textCommands?: TextCommandInfo<TState, UseThis>[];
+    textCommands?: TextCommandInfo[];
     slashCommands?: never; // not yet implemented
-    eventListeners?: { [EventName in keyof ClientEvents]: (state: TState, ...args: ClientEvents[EventName]) => Awaited<void> };
+    eventListeners?: { [EventName in keyof ClientEvents]: (...args: ClientEvents[EventName]) => Awaited<void> };
 }
 
-export function makePlugin<T, UseThis extends boolean>(plugin: Plugin<T, UseThis>) {
+export type Plugin = (client: GompeiClient) => PluginInfo;
+
+export function Plugin(plugin: Plugin) {
     return plugin;
 }

--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -1,17 +1,33 @@
-import { makePlugin } from "./Plugin";
+import parseCommandArguments from "../util/parseCommandArguments";
+import { Plugin } from "./Plugin";
 
-export default makePlugin({
-    name: 'Logging',
-    init: (client) => ({
-        client,
-        statuses: []
-    }),
-    textCommands: [
-        {
-            commandName: 'logging',
-            callback: (state, msg) => {
-                console.log(msg.content);
+export default Plugin(client => {
+    let commandsFired = 0;
+
+    return {
+        name: 'Logging',
+        textCommands: [
+            {
+                commandName: 'logging',
+                callback: async (ctx) => {
+                    commandsFired++;
+                    try {
+                        await parseCommandArguments(ctx, 'exact:number');
+                        ctx.channel.send(`Commands have been fired ${commandsFired} times.`)
+                    }
+                    catch (_) {
+                        console.log(ctx.content);
+                    }
+                }
+            },
+            {
+                commandName: 'channel',
+                callback: async (ctx) => {
+                    const [channel, rest] = await parseCommandArguments(ctx, 'textChannel', 'rest');
+                    commandsFired++;
+                    ctx.channel.send(`Sent "${rest}" in ${channel}`);
+                }
             }
-        }
-    ]
+        ]
+    };   
 });

--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -1,7 +1,5 @@
-import { GuildAuditLogs, GuildAuditLogsEntry, Message, MessageEmbed, Permissions, TextChannel } from "discord.js";
+import { GuildAuditLogs, MessageEmbed, TextChannel } from "discord.js";
 import { Store } from "../storage";
-import { textCommandPrefix } from "../shared";
-import parseCommandArguments from "../util/parseCommandArguments";
 import { isAdmin } from "../util/permsValidator";
 import { Plugin } from "./Plugin";
 
@@ -69,7 +67,7 @@ export default Plugin(client => {
                 commandName: 'logging',
                 check: isAdmin,
                 async callback(ctx) {
-                    const [channel] = await Promise.all(ctx.parseArguments('textChannel'));
+                    const [channel] = await ctx.parseArgumentsAsync('textChannel');
 
                     const guildStore = storage.for(channel.guildId);
 

--- a/src/plugins/logging.ts
+++ b/src/plugins/logging.ts
@@ -1,33 +1,146 @@
+import { GuildAuditLogs, GuildAuditLogsEntry, Message, MessageEmbed, Permissions, TextChannel } from "discord.js";
+import { Store } from "../storage";
+import { textCommandPrefix } from "../shared";
 import parseCommandArguments from "../util/parseCommandArguments";
+import { isAdmin } from "../util/permsValidator";
 import { Plugin } from "./Plugin";
 
+interface LoggingStoreData {
+    [guildId: string]: GuildStoreData;
+}
+
+interface GuildStoreData {
+    loggingChannel: string | undefined;
+    lastAudit: boolean;
+}
+
+class LoggingStore extends Store<LoggingStoreData> {
+    configName = 'logging';
+    protected defaultConfig = {};
+
+    private cache: LoggingStoreData = this.defaultConfig;
+
+    private async commit() {
+        return this.save(this.cache);
+    }
+
+    override async init() {
+        this.cache = await this.fetch();
+    }
+
+    private getOrInitGuild(guild: string) {
+        return (this.cache[guild] ??= {
+            loggingChannel: undefined,
+            lastAudit: true
+        });
+    }
+
+    for(guildId: string): GuildStoreData {
+        const commit = this.commit.bind(this);
+        const guildStoreCache = this.getOrInitGuild(guildId);
+        return {
+            get loggingChannel() {
+                return guildStoreCache.loggingChannel;
+            },
+            set loggingChannel(val) {
+                guildStoreCache.loggingChannel = val;
+                commit();
+            },
+
+            get lastAudit() {
+                return guildStoreCache.lastAudit;
+            },
+            set lastAudit(val) {
+                guildStoreCache.lastAudit = val;
+                commit();
+            },
+        };
+    }
+}
+
 export default Plugin(client => {
-    let commandsFired = 0;
+    const [storage, latch] = client.storage.load(LoggingStore);
 
     return {
         name: 'Logging',
+        latch,
         textCommands: [
             {
                 commandName: 'logging',
-                callback: async (ctx) => {
-                    commandsFired++;
-                    try {
-                        await parseCommandArguments(ctx, 'exact:number');
-                        ctx.channel.send(`Commands have been fired ${commandsFired} times.`)
+                check: isAdmin,
+                async callback(ctx) {
+                    const [channel] = await Promise.all(ctx.parseArguments('textChannel'));
+
+                    const guildStore = storage.for(channel.guildId);
+
+                    if (guildStore.loggingChannel === channel.id) {
+                        ctx.channel.send(`${channel} is already being used for logging.`);
                     }
-                    catch (_) {
-                        console.log(ctx.content);
+                    else {
+                        guildStore.loggingChannel = channel.id;
+    
+                        ctx.channel.send(`Successfully updated logging channel to ${channel}.`);
                     }
-                }
-            },
-            {
-                commandName: 'channel',
-                callback: async (ctx) => {
-                    const [channel, rest] = await parseCommandArguments(ctx, 'textChannel', 'rest');
-                    commandsFired++;
-                    ctx.channel.send(`Sent "${rest}" in ${channel}`);
                 }
             }
-        ]
-    };   
+        ],
+        eventListeners: {
+            'messageDelete': async message => {
+                if (message.channel.type === 'DM' || !message.guildId || !message.guild) return;
+                const guildStore = storage.for(message.guildId);
+
+                if (!guildStore.loggingChannel) return;
+
+                if (!message.author?.bot) {
+                    const embed = new MessageEmbed({
+                        title: `Message deleted in #${message.channel.name}`,
+                        color: 0xbe4041,
+                        description: message.content!
+                    });
+
+                    const prevMessage = (await message.channel.messages.fetch({ before: message.id, limit: 1 })).first();
+                    if (prevMessage) {
+                        embed.description += `\n[Previous Message](${prevMessage.url})`
+                    }
+
+                    if (message.reference) {
+                        try {
+                            await message.channel.messages.fetch(message.reference.messageId!)
+                            embed.addField(
+                                'Reply to',
+                                `https://discord.com/channels/${message.reference.guildId}/${message.reference.channelId}/${message.reference.messageId}`
+                            );
+                        }
+                        catch (e) {
+                            embed.description += '\nReplied to deleted message';
+                        }
+                    }
+
+                    if (message.attachments.size > 0) {
+                        embed.addFields(message.attachments.map(x => ({
+                            name: "Attachment",
+                            value: x.proxyURL
+                        })));
+                    }
+
+                    if (guildStore.lastAudit) {
+                        const auditLog = (await message.guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.MESSAGE_DELETE, limit: 1 })).entries.first();
+    
+                        if (auditLog) {
+                            embed.description += `\n\n**Deleted by ${auditLog.executor}**`;
+                        }
+                    }
+
+                    embed.setAuthor(
+                            `${message.author?.username}#${message.author?.discriminator}`,
+                            message.author?.avatarURL()!)
+                        .setFooter(`ID: ${message.author?.id}`)
+                        .setTimestamp(Date.now());
+                    
+                    const loggingChannel = await message.guild?.channels.fetch(guildStore.loggingChannel) as TextChannel;
+                    loggingChannel.send({ embeds: [embed] });
+                }
+            }
+        }
+    };
 });

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,1 @@
+export const textCommandPrefix = process.env.PREFIX ?? '.';

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,45 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export class StorageManager {
+    private configs = new Map<new () => Store, [Store, Promise<void>]>();
+
+    load<T extends Store>(Config: new () => T): [T, Promise<void>] {
+        if (this.configs.has(Config)) {
+            return this.configs.get(Config) as [T, Promise<void>];
+        }
+        const config = new Config();
+        const configPromise = config.init();
+        this.configs.set(Config, [config, configPromise]);
+        return [config, configPromise];
+    }
+}
+
+export abstract class Store<T = any> {
+    abstract configName: string;
+    protected abstract defaultConfig: T;
+
+    private get path() {
+        return path.resolve(process.env.STORAGE_PATH ?? './storage/', `${this.configName}.json`)
+    }
+
+    abstract init(): Promise<void>;
+
+    async fetch(): Promise<T> {
+        try {
+            await fs.stat(this.path)
+            const contents = await fs.readFile(this.path, { encoding: 'utf-8' });
+            const result = JSON.parse(contents);
+            return result;
+        }
+        catch (e) {
+            return this.defaultConfig;
+        }
+    }
+
+    protected async save(value: T) {
+        await fs.mkdir(path.dirname(this.path), { recursive: true });
+        await fs.writeFile(this.path, JSON.stringify(value), { encoding: 'utf-8' });
+    }
+}
+

--- a/src/util/parseCommandArguments.ts
+++ b/src/util/parseCommandArguments.ts
@@ -24,22 +24,20 @@ export type ArgumentType = keyof ArgumentTypeMap | RegExp;
 
 export type ArgumentList = [...Exclude<ArgumentType, 'rest'>[], ...(['rest'] | [])];
 
-type ConvertArgumentList<T extends ArgumentType[]>
+export type ParseArgumentsReturnType<T extends ArgumentType[]>
     = T extends [infer Arg, ...infer Rest]
     ? Arg extends keyof ArgumentTypeMap
         // @ts-expect-error Remove this comment once the ts bug gets fixed
-        ? [ArgumentTypeMap[Arg], ...ConvertArgumentList<Rest>]
+        ? [ArgumentTypeMap[Arg], ...ParseArgumentsReturnType<Rest>]
         // @ts-expect-error Remove this comment once the ts bug gets fixed
-        : [string, ...ConvertArgumentList<Rest>]
+        : [string, ...ParseArgumentsReturnType<Rest>]
     : [];
-
-type x = ConvertArgumentList<['string', 'int', 'regex:/abc/i']>
 
 export default function parseArgumentsFactory(argumentContent: string) {
     return function parseArguments<T extends ArgumentList>(
         this: TextCommandContext,
         ...types: T
-    ): ConvertArgumentList<T> {
+    ): ParseArgumentsReturnType<T> {
         let rest = argumentContent;
         const args = [];
         

--- a/src/util/parseCommandArguments.ts
+++ b/src/util/parseCommandArguments.ts
@@ -21,10 +21,6 @@ export type ArgumentTypeMap = {
     [Key in string as `${typeof REGEX}/${string}/${string}`]: string;
 };
 
-interface IFoo {
-    foo: number;
-}
-
 export type ArgumentType = keyof ArgumentTypeMap | RegExp | `${typeof EXACT}${string}`;
 
 export type ArgumentList = [...Exclude<ArgumentType, 'rest'>[], ...(['rest'] | [])];

--- a/src/util/parseCommandArguments.ts
+++ b/src/util/parseCommandArguments.ts
@@ -1,0 +1,154 @@
+import { GuildMember, Invite, Role, TextChannel } from "discord.js";
+import { TextCommandContext } from "../plugins/Plugin";
+import { partition } from "./string";
+
+export class InvalidArgumentError extends TypeError { }
+
+const EXACT = 'exact:' as const;
+const REGEX = 'regex:' as const;
+
+export type ArgumentTypeMap = {
+    number: number;
+    int: number;
+    string: string;
+    rest: string;
+    textChannel: TextChannel;
+    member: GuildMember;
+    role: Role;
+    invite: Invite;
+} & {
+    [Key in string as `${typeof EXACT}${Key}` | `${typeof REGEX}/${string}/${string}`]: string;
+};
+
+export type ArgumentType = keyof ArgumentTypeMap | RegExp;
+
+export type ArgumentList = [...Exclude<ArgumentType, 'rest'>[], ...(['rest'] | [])];
+
+type ConvertArgumentList<T extends ArgumentType[]>
+    = T extends [infer Arg, ...infer Rest]
+    ? Arg extends keyof ArgumentTypeMap
+        // @ts-expect-error Remove this comment once the ts bug gets fixed
+        ? [ArgumentTypeMap[Arg], ...ConvertArgumentList<Rest>]
+        // @ts-expect-error Remove this comment once the ts bug gets fixed
+        : [string, ...ConvertArgumentList<Rest>]
+    : [];
+
+type x = ConvertArgumentList<['string', 'int', 'regex:/abc/i']>
+
+export default async function parseCommandArguments<T extends ArgumentList>(
+    ctx: TextCommandContext,
+    ...types: T
+): Promise<ConvertArgumentList<T>> {
+    let rest = ctx.argumentContent;
+    const args = [];
+    
+    for (const type of types) {
+        if (type === 'rest') {
+            args.push(rest);
+            break;
+        }
+        if (type === 'string') {
+            // parse strings
+        }
+
+        const [argContent, _rest] = partition(rest, ' ');
+        rest = _rest;
+
+        if (type instanceof RegExp || type.startsWith(REGEX)) {
+            let regexp: RegExp;
+            if (typeof type === 'string') {
+                const [, pattern, flags] = type.split('/');
+                regexp = RegExp(pattern, flags);
+            }
+            else {
+                regexp = type;
+            }
+            if (regexp.test(argContent)) {
+                args.push(argContent);
+                continue;
+            }
+            throw new InvalidArgumentError(`${argContent} does not satisfy ${regexp}`)
+        }
+
+        if (type.startsWith(EXACT)) {
+            const field = type.slice(EXACT.length);
+            if (field.split('|').includes(argContent)) {
+                args.push(argContent);
+                continue;
+            }
+            throw new InvalidArgumentError(`${argContent} is not one of ${field}`);
+        }
+
+        switch (type) {
+            case 'string':
+                // remove once quoted string parsing is written
+                args.push(argContent);
+                continue;
+            case 'number': {
+                const arg = +argContent;
+                if (isNaN(arg)) {
+                    throw new InvalidArgumentError(`${argContent} is not a number`);
+                }
+                args.push(arg);
+                continue;
+            }
+            case 'int': {
+                const arg = +argContent;
+                if (arg % 1 !== 0) {
+                    throw new InvalidArgumentError(`${argContent} is not an integer`);
+                }
+                args.push(arg);
+                continue;
+            }
+            case 'textChannel':
+                args.push(
+                    parseMaybeMention('#', argContent)
+                        .then(x => ctx.guild?.channels.fetch(x) ?? Promise.reject())
+                        .then(ch => ch?.type === 'GUILD_TEXT' ? ch : Promise.reject())
+                        .catch(() => {
+                            throw new InvalidArgumentError(`Channel ${argContent} could not be found`)
+                        })
+                );
+                continue;
+            case 'member':
+                args.push(
+                    parseMaybeMention('@!', argContent)
+                        .catch(() => parseMaybeMention('@', argContent))
+                        .then(x => ctx.guild?.members.fetch(x) ?? Promise.reject())
+                        .catch(() => {
+                            throw new InvalidArgumentError(`Member ${argContent} could not be found`)
+                        })
+                );
+                continue;
+            case 'role':
+                args.push(
+                    parseMaybeMention('@&', argContent)
+                        .then(x => ctx.guild?.roles.fetch(x) ?? Promise.reject())
+                        .catch(() => {
+                            throw new InvalidArgumentError(`Role ${argContent} could not be found`)
+                        })
+                );
+                continue;
+            case 'invite':
+                args.push(
+                    ctx.guild?.invites.fetch(argContent)
+                        .catch(() => {
+                            throw new InvalidArgumentError(`Invite code ${argContent} could not be found`)
+                        })
+                );
+                continue;
+        }
+    }
+
+    return Promise.all(args as any[]) as any;
+}
+
+async function parseMaybeMention(sigil: string, content: string) {
+    if (!content.startsWith('<')) {
+        return content;
+    }
+    if (content.startsWith(`<${sigil}`) && content.endsWith('>')) {
+        return content.slice(sigil.length + 1, -1);
+    }
+    throw new InvalidArgumentError();
+}

--- a/src/util/parseCommandArguments.ts
+++ b/src/util/parseCommandArguments.ts
@@ -12,10 +12,10 @@ export type ArgumentTypeMap = {
     int: number;
     string: string;
     rest: string;
-    textChannel: TextChannel;
-    member: GuildMember;
-    role: Role;
-    invite: Invite;
+    textChannel: Promise<TextChannel>;
+    member: Promise<GuildMember>;
+    role: Promise<Role>;
+    invite: Promise<Invite>;
 } & {
     [Key in string as `${typeof EXACT}${Key}` | `${typeof REGEX}/${string}/${string}`]: string;
 };
@@ -35,115 +35,120 @@ type ConvertArgumentList<T extends ArgumentType[]>
 
 type x = ConvertArgumentList<['string', 'int', 'regex:/abc/i']>
 
-export default async function parseCommandArguments<T extends ArgumentList>(
-    ctx: TextCommandContext,
-    ...types: T
-): Promise<ConvertArgumentList<T>> {
-    let rest = ctx.argumentContent;
-    const args = [];
+export default function parseArgumentsFactory(argumentContent: string) {
+    return function parseArguments<T extends ArgumentList>(
+        this: TextCommandContext,
+        ...types: T
+    ): ConvertArgumentList<T> {
+        let rest = argumentContent;
+        const args = [];
+        
+        for (const type of types) {
+            if (type === 'rest') {
+                args.push(rest);
+                break;
+            }
+            if (type === 'string') {
+                // parse strings
+            }
     
-    for (const type of types) {
-        if (type === 'rest') {
-            args.push(rest);
-            break;
-        }
-        if (type === 'string') {
-            // parse strings
-        }
-
-        const [argContent, _rest] = partition(rest, ' ');
-        rest = _rest;
-
-        if (type instanceof RegExp || type.startsWith(REGEX)) {
-            let regexp: RegExp;
-            if (typeof type === 'string') {
-                const [, pattern, flags] = type.split('/');
-                regexp = RegExp(pattern, flags);
-            }
-            else {
-                regexp = type;
-            }
-            if (regexp.test(argContent)) {
-                args.push(argContent);
-                continue;
-            }
-            throw new InvalidArgumentError(`${argContent} does not satisfy ${regexp}`)
-        }
-
-        if (type.startsWith(EXACT)) {
-            const field = type.slice(EXACT.length);
-            if (field.split('|').includes(argContent)) {
-                args.push(argContent);
-                continue;
-            }
-            throw new InvalidArgumentError(`${argContent} is not one of ${field}`);
-        }
-
-        switch (type) {
-            case 'string':
-                // remove once quoted string parsing is written
-                args.push(argContent);
-                continue;
-            case 'number': {
-                const arg = +argContent;
-                if (isNaN(arg)) {
-                    throw new InvalidArgumentError(`${argContent} is not a number`);
+            const [argContent, _rest] = partition(rest, ' ');
+            rest = _rest;
+    
+            if (type instanceof RegExp || type.startsWith(REGEX)) {
+                let regexp: RegExp;
+                if (typeof type === 'string') {
+                    const [, pattern, flags] = type.split('/');
+                    regexp = RegExp(pattern, flags);
                 }
-                args.push(arg);
-                continue;
-            }
-            case 'int': {
-                const arg = +argContent;
-                if (arg % 1 !== 0) {
-                    throw new InvalidArgumentError(`${argContent} is not an integer`);
+                else {
+                    regexp = type;
                 }
-                args.push(arg);
-                continue;
+                if (regexp.test(argContent)) {
+                    args.push(argContent);
+                    continue;
+                }
+                throw new InvalidArgumentError(`${argContent} does not satisfy ${regexp}`)
             }
-            case 'textChannel':
-                args.push(
-                    parseMaybeMention('#', argContent)
-                        .then(x => ctx.guild?.channels.fetch(x) ?? Promise.reject())
-                        .then(ch => ch?.type === 'GUILD_TEXT' ? ch : Promise.reject())
-                        .catch(() => {
-                            throw new InvalidArgumentError(`Channel ${argContent} could not be found`)
-                        })
-                );
-                continue;
-            case 'member':
-                args.push(
-                    parseMaybeMention('@!', argContent)
-                        .catch(() => parseMaybeMention('@', argContent))
-                        .then(x => ctx.guild?.members.fetch(x) ?? Promise.reject())
-                        .catch(() => {
-                            throw new InvalidArgumentError(`Member ${argContent} could not be found`)
-                        })
-                );
-                continue;
-            case 'role':
-                args.push(
-                    parseMaybeMention('@&', argContent)
-                        .then(x => ctx.guild?.roles.fetch(x) ?? Promise.reject())
-                        .catch(() => {
-                            throw new InvalidArgumentError(`Role ${argContent} could not be found`)
-                        })
-                );
-                continue;
-            case 'invite':
-                args.push(
-                    ctx.guild?.invites.fetch(argContent)
-                        .catch(() => {
-                            throw new InvalidArgumentError(`Invite code ${argContent} could not be found`)
-                        })
-                );
-                continue;
+    
+            if (type.startsWith(EXACT)) {
+                const field = type.slice(EXACT.length);
+                if (field.split('|').includes(argContent)) {
+                    args.push(argContent);
+                    continue;
+                }
+                throw new InvalidArgumentError(`${argContent} is not one of ${field}`);
+            }
+    
+            switch (type) {
+                case 'string':
+                    // remove once quoted string parsing is written
+                    args.push(argContent);
+                    continue;
+                case 'number': {
+                    const arg = +argContent;
+                    if (isNaN(arg)) {
+                        throw new InvalidArgumentError(`${argContent} is not a number`);
+                    }
+                    args.push(arg);
+                    continue;
+                }
+                case 'int': {
+                    const arg = +argContent;
+                    if (arg % 1 !== 0) {
+                        throw new InvalidArgumentError(`${argContent} is not an integer`);
+                    }
+                    args.push(arg);
+                    continue;
+                }
+                case 'textChannel':
+                    args.push(
+                        Promise.resolve()
+                            .then(() => parseMaybeMention('#', argContent))
+                            .then(x => this.guild?.channels.fetch(x) ?? Promise.reject())
+                            .then(ch => ch?.type === 'GUILD_TEXT' ? ch : Promise.reject())
+                            .catch(() => {
+                                throw new InvalidArgumentError(`Channel ${argContent} could not be found`)
+                            })
+                    );
+                    continue;
+                case 'member':
+                    args.push(
+                        Promise.resolve()
+                            .then(() => parseMaybeMention('@!', argContent))
+                            .catch(() => parseMaybeMention('@', argContent))
+                            .then(x => this.guild?.members.fetch(x) ?? Promise.reject())
+                            .catch(() => {
+                                throw new InvalidArgumentError(`Member ${argContent} could not be found`)
+                            })
+                    );
+                    continue;
+                case 'role':
+                    args.push(
+                        Promise.resolve()
+                            .then(() => parseMaybeMention('@&', argContent))
+                            .then(x => this.guild?.roles.fetch(x) ?? Promise.reject())
+                            .catch(() => {
+                                throw new InvalidArgumentError(`Role ${argContent} could not be found`)
+                            })
+                    );
+                    continue;
+                case 'invite':
+                    args.push(
+                        this.guild?.invites.fetch(argContent)
+                            .catch(() => {
+                                throw new InvalidArgumentError(`Invite code ${argContent} could not be found`)
+                            })
+                    );
+                    continue;
+            }
         }
+    
+        return args as any;
     }
-
-    return Promise.all(args as any[]) as any;
 }
 
-async function parseMaybeMention(sigil: string, content: string) {
+function parseMaybeMention(sigil: string, content: string) {
     if (!content.startsWith('<')) {
         return content;
     }

--- a/src/util/permsValidator.ts
+++ b/src/util/permsValidator.ts
@@ -1,0 +1,12 @@
+import { PermissionResolvable, Permissions } from "discord.js";
+import { TextCommandContext } from "../plugins/Plugin";
+
+export class AuthorizationError extends Error {}
+
+export function permsFactory(permissions: PermissionResolvable) {
+    return function(ctx: TextCommandContext) {
+        return ctx.member?.permissions.has(permissions, true) ?? false;
+    };
+}
+
+export const isAdmin = permsFactory(Permissions.FLAGS.ADMINISTRATOR); 

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -1,0 +1,7 @@
+export function partition(str: string, substring: string): [string, string] {
+    const index = str.indexOf(substring);
+    if (index === -1) {
+        return [str, ''];
+    }
+    return [str.slice(0, index), str.slice(index + substring.length)];
+}

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -1,0 +1,6 @@
+type ClearPromises<T extends any[]> =
+    T extends [infer P, ...infer Rest]
+    ? P extends Promise<infer X>
+        ? [X, ...ClearPromises<Rest>]
+        : [P, ...ClearPromises<Rest>]
+    : [];

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -1,6 +1,11 @@
-type ClearPromises<T extends any[]> =
+export type ClearPromises<T extends any[]> =
     T extends [infer P, ...infer Rest]
     ? P extends Promise<infer X>
         ? [X, ...ClearPromises<Rest>]
         : [P, ...ClearPromises<Rest>]
     : [];
+
+export type Split<T extends string, Splitter extends string> =
+    T extends `${infer A}${Splitter}${infer B}`
+    ? A | Split<B, Splitter>
+    : T;

--- a/src/util/types.d.ts
+++ b/src/util/types.d.ts
@@ -1,8 +1,0 @@
-export type Thisify<
-    UseThis extends boolean,
-    T extends (...args: any[]) => any
-> = Parameters<T> extends [infer State, ...infer TArgs]
-    ? UseThis extends true
-        ? (this: State, ...any: TArgs) => ReturnType<T>
-        : T
-    : T;


### PR DESCRIPTION
The previous plugin API was pretty fragile from a typing perspective. This new version should be much more solid.

Also added argument parsing and a basic storage (config) API. See `src\plugins\logging.ts` for some examples of actual plugin code. It's fairly similar to the old python version.

Argument parsing is quite fancy from a typing perspective. Since typescript doesn't (natively) support type introspection for function arguments, I can't make the argument parsing API _quite_ as nice as it was in Python. However, this is hopefully close enough:

```ts
const [addOrRemove, channel, str] = await ctx.parseArgumentsAsync('exact:add|remove', 'textChannel', 'string');
// parses first three space-separated command arguments
// addOrRemove is type `"add" | "remove"`
// channel is type `TextChannel`
// str is type `string`
```

As for the storage API, it's fairly basic, but it supports pretty much what the original python bot supported, just in a slightly different format.